### PR TITLE
Removing references and links to twitter

### DIFF
--- a/_includes/speaker_box.html
+++ b/_includes/speaker_box.html
@@ -37,19 +37,6 @@
 </div>
 <div class="speaker-info" id="{{ speaker.id }}-info">
     <div class="speaker-info-inner">
-        {% if speaker.twitter_handle.size > 0 %}
-			<p class="speaker-bio">
-				<span class="icon icon--twitter">
-				  <a href="https://twitter.com/{{ speaker.twitter_handle }}" title="@{{ speaker.twitter_handle }} on Twitter">
-					  <svg viewBox="0 0 18 18">
-						  <path fill="#006272" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
-						  c-0.632,0.375-1.332,0.647-2.076,0.793c-0.596-0.636-1.446-1.033-2.387-1.033c-1.806,0-3.27,1.464-3.27,3.27 c0,0.256,0.029,0.506,0.085,0.745C5.163,5.404,2.753,4.102,1.14,2.124C0.859,2.607,0.698,3.168,0.698,3.767 c0,1.134,0.577,2.135,1.455,2.722C1.616,6.472,1.112,6.325,0.671,6.08c0,0.014,0,0.027,0,0.041c0,1.584,1.127,2.906,2.623,3.206 C3.02,9.402,2.731,9.442,2.433,9.442c-0.211,0-0.416-0.021-0.615-0.059c0.416,1.299,1.624,2.245,3.055,2.271 c-1.119,0.877-2.529,1.4-4.061,1.4c-0.264,0-0.524-0.015-0.78-0.046c1.447,0.928,3.166,1.469,5.013,1.469 c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"></path>
-					  </svg>
-					<span class="username" aria-hidden="true">{{ speaker.twitter_handle }}</span>
-				  </a>
-				</span>
-			</p>
-        {% endif %}
 		{% if speaker.image_alt.size > 0 %}
 		    <h4 class="image-description">Profile Image Description</h4>
 		    <p class="image-description">{{ speaker.image_alt }}</p>

--- a/assets/_scss/_speakers.scss
+++ b/assets/_scss/_speakers.scss
@@ -81,20 +81,6 @@ p.speaker-session a {
   }
 }
 
-// Links to twitter usernames for speakers & scholarships
-p.speaker-bio .icon--twitter a,
-dt .speaker-bio .icon.icon--twitter a {
-  border-bottom: 0;
-
-  &:hover,
-  &:focus,
-  &:active {
-		background-color: transparent;
-		border-bottom: 0;
-		color: $black;
-  }
-}
-
 p.speaker-bio:not(:nth-of-type(1)) {
   margin-bottom: 5px;
   padding-top: 0;

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -217,9 +217,8 @@ active: Attend Code4Lib
                 <p>
                     You can also connect with us via
                     <a href="{{ site.data.conf.social-links.slack}}">Slack</a>
-                    (<a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">sign up here</a>),
-                    <a href="https://twitter.com/hashtag/{{site.data.conf.hashtag}}">Twitter</a>, and
-                    <a href="{{ site.data.conf.social-links.irc}}">IRC</a>.
+                    (<a href="https://docs.google.com/forms/d/120Dw1JjLxPJB9VTGl0mUY7Ot6yg6YNY1RZUISJFzdwk/viewform?c=0&w=1">sign up here</a>)
+                    and <a href="{{ site.data.conf.social-links.irc}}">IRC</a>.
                 </p>
 
                 {% if site.data.conf.closed-captioning.show %}

--- a/general-info/first-timers.html
+++ b/general-info/first-timers.html
@@ -115,7 +115,7 @@ active: First Timers
       <p>
         There will be A LOT of information thrown at you in a short period of time at code4lib. You will be mentally exhausted before conference end.
         For reference, the majority of folks “hit the wall” around the afternoon of the second full day. If you need to take a break, do so.
-        {% if site.data.conf.quiet-room.show %}You can decompress outside the conference hall in <a href="{{ '/general-info/accessibility#quietroom' | relative_url }}">the quiet room</a>.{% endif %} Try a <a href="https://twitter.com/search?f=tweets&vertical=default&q=%23nap4lib&src=typd">#nap4lib</a>!
+        {% if site.data.conf.quiet-room.show %}You can decompress outside the conference hall in <a href="{{ '/general-info/accessibility#quietroom' | relative_url }}">the quiet room</a>.{% endif %} Try a nap!
         The talks are recorded, so you can catch up on anything you might have missed during your break.
       </p>
 
@@ -123,7 +123,7 @@ active: First Timers
       <h2>Other Note</h2>
       <p>
         If nothing else - if you have a question, ask! Ask the conference volunteers, folks who look like they know what they’re doing, folks who don’t exactly look like they know what they’re doing,
-        the <a href="http://code4lib.slack.com">Slack channel</a>, <a href="https://twitter.com/hashtag/{{site.data.conf.hashtag}}">Twitter</a>, or <a href="http://code4lib.org/irc">IRC</a> streams - the choices are plentiful.
+        the <a href="http://code4lib.slack.com">Slack channel</a>, or <a href="http://code4lib.org/irc">IRC</a> streams - the choices are plentiful.
       </p>
       <p>
         Thank and see you at the conference!

--- a/general-info/venues/libtechwomen.html
+++ b/general-info/venues/libtechwomen.html
@@ -7,7 +7,7 @@
             <a href="http://libtechwomen.org/">LibTechWomen</a> is a supportive space for women and their friends to network, develop skills, build confidence, and lead positive change. 
             Are you a lurker? Are you a newcomer? All are welcome!
             <br>
-            Food and beverages are available for purchase at the bar, and afterwards some of us will go to Game Night or Karaoke!  Come chat with fellow <a href="https://twitter.com/hashtag/{{site.data.conf.libtech-women.hashtag}} ">#{{site.data.conf.libtech-women.hashtag}}</a> people and meet wonderful colleagues in library technology!<br>
+            Food and beverages are available for purchase at the bar, and afterwards some of us will go to Game Night or Karaoke!  Come chat with fellow #{{site.data.conf.libtech-women.hashtag}} people and meet wonderful colleagues in library technology!<br>
 
         </p>
     </div>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ title: code4lib 2025
                         {{ testimonial.blurb }}
                     </div>
                     <div class="caption">
-                        <h3><a href="https://twitter.com/{{ testimonial.twitter }}">{{ testimonial.name }}</a></h3>
+                        <h3>{{ testimonial.name }}</h3>
                         <p>{{ testimonial.org }}</p>
                     </div>
                 </div>


### PR DESCRIPTION
As twitter has become increasingly incompatible with our values, community activity has dropped off. We shouldn't be linking to it and sending the signal that we are active there.