### PR TITLE
Open up call for workshop proposals

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -254,9 +254,9 @@ keynote-proposals:
   end-date: '2024-11-22'
 
 workshop-proposals:
-  show: false
-  submission-form: 'https://forms.gle/XxG9n5G5wVskwK8v7'
-  end-date: '2023-11-30'
+  show: true
+  submission-form: 'https://docs.google.com/forms/d/e/1FAIpQLSchZV9hUVHG7rzp0LEqSdzNrRlvrc3JYqcNODBFIFNuZu5raA/viewform?usp=sf_link'
+  end-date: '2024-11-20'
 
 talk-proposals:
   show: false

--- a/_includes/homepage/pre_conference.html
+++ b/_includes/homepage/pre_conference.html
@@ -175,7 +175,7 @@
             <!-- Workshops -->
             {% if site.data.conf.workshop-proposals.show %}
                 {% include homepage/going_on_block.html
-                    title='Conference Workshops'
+                    title='Post-Conference Workshops'
                     end-date=site.data.conf.workshop-proposals.end-date
                     url=site.data.conf.workshop-proposals.submission-form
                     url-text='Propose a workshop'


### PR DESCRIPTION
Opened up CFP for post-conference workshops per Kathy Azevedo on Slack https://code4lib.slack.com/archives/C0D9KS1EU/p1730835623916069. Set title to say Post-Conference since there was some confusion and irriation about that in the past.