### PR TITLE
Fixed group header typo 🛠️📝

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -155,7 +155,7 @@
   time: 14:30-15:35
 
 - timeImg: 3.50.png
-  title: Group 2&#58; 80 minutes (5 talks)
+  title: Group 3&#58; 80 minutes (5 talks)
   day1: true
   groupId: 3
   time: 15:50-17:00


### PR DESCRIPTION
Group 3 was mistakenly labeled Group 2, just like the other Group 2
